### PR TITLE
リレーションの定義、ブログ全記事の表示、カテゴリーでの絞り込みの実装

### DIFF
--- a/src/main/java/com/example/demo/aop/CheckLoginAspect.java
+++ b/src/main/java/com/example/demo/aop/CheckLoginAspect.java
@@ -34,17 +34,13 @@ public class CheckLoginAspect {
 
 	// 未ログインの場合ログインページにリダイレクト
 	// `*` は「すべての戻り値・メソッド名」に、`(..)` は「すべての引数の組み合わせ」に
-	@Around("execution(* com.example.demo.controller.UserController.*(..)) ||"
-			+ "execution(* com.example.demo.controller.BlogController.*(..))")
+	@Around("execution(* com.example.demo.controller.BlogController.*(..))")
 	public Object checkLogin(ProceedingJoinPoint jp) throws Throwable {
 
 		if (account == null || account.getName() == null
 				|| account.getName().length() == 0) {
 			System.err.println("ログインしていません!");
 
-			// リダイレクト先を指定する
-			// パラメータを渡すことでログインControllerで
-			// 個別のメッセージをThymeleafに渡すことも可能
 			return "redirect:/login?error=notLoggedIn";
 		}
 		// jp.proceed()でコントローラーの処理を実行

--- a/src/main/java/com/example/demo/controller/BlogController.java
+++ b/src/main/java/com/example/demo/controller/BlogController.java
@@ -1,5 +1,57 @@
 package com.example.demo.controller;
 
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.example.demo.entity.Blog;
+import com.example.demo.entity.Category;
+import com.example.demo.repository.BlogRepository;
+import com.example.demo.repository.CategoryRepository;
+
+@Controller
 public class BlogController {
+
+	@Autowired
+	private CategoryRepository categoryRepository;
+
+	@Autowired
+	private BlogRepository blogRepository;
+
+	// ブログ一覧画面の表示
+	@GetMapping("/blogs")
+	public String index(
+			@RequestParam(defaultValue = "") Integer categoryId,
+			Model model) {
+
+		// 全カテゴリーの取得
+		List<Category> categoryList = categoryRepository.findAll();
+		model.addAttribute("categories", categoryList);
+
+		// 全てのユーザーのブログ記事の一覧情報を取得
+		List<Blog> blogList = null;
+		if (categoryId == null) {
+			blogList = blogRepository.findAll();
+		} else {
+			blogList = blogRepository.findByCategoryId(categoryId);
+		}
+
+		// 取得した記事一覧をテンプレートに渡す
+		model.addAttribute("blogs", blogList);
+
+		return "blogs";
+	}
+
+	// ブログ変更画面の表示
+	@GetMapping("/blogs/edit")
+	public String update(
+			@RequestParam Integer blogId,
+			Model model) {
+		return "editBlog";
+	}
 
 }

--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.example.demo.entity.User;
+import com.example.demo.model.Account;
 import com.example.demo.repository.UserRepository;
 
 @Controller
@@ -21,6 +22,9 @@ public class UserController {
 
 	@Autowired
 	private HttpSession session;
+
+	@Autowired
+	private Account account;
 
 	// 新規ユーザー登録画面の表示
 	@GetMapping("/users/add")
@@ -52,8 +56,13 @@ public class UserController {
 			@RequestParam(defaultValue = "") String error,
 			Model model) {
 
-		// セッション情報をクリア
+		// セッション情報全てをクリア
 		session.invalidate();
+
+		// クエリパラメータで"notLoggedIn"を受け取った場合
+		if (error.equals("notLoggedIn")) {
+			model.addAttribute("message", "ログインしてください");
+		}
 
 		return "login";
 	}
@@ -80,7 +89,9 @@ public class UserController {
 			return "login";
 		}
 
-		session.setAttribute("user", user);
+		// ログイン情報をAccountに保存
+		account.setId(user.getId());
+		account.setName(user.getName());
 
 		return "redirect:/blogs";
 	}

--- a/src/main/java/com/example/demo/entity/Blog.java
+++ b/src/main/java/com/example/demo/entity/Blog.java
@@ -1,10 +1,11 @@
 package com.example.demo.entity;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 @Entity
@@ -14,11 +15,13 @@ public class Blog {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer id; // 記事ID(blogsテーブルのid)
 
-	@Column(name = "category_id") // blogsテーブルのcategory_id
-	private Integer categoryId; // カテゴリーID
+	@ManyToOne // 多対１のリレーション：多くのブログが１つのカテゴリーに属するから
+	@JoinColumn(name = "category_id") // blogsテーブルの外部キー（category_id）
+	private Category category; // リレーション先のエンティティを指定
 
-	@Column(name = "user_id") // blogsテーブルのuser_id
-	private Integer userId; // ユーザーID
+	@ManyToOne
+	@JoinColumn(name = "user_id") // blogsテーブルの外部キー（user_id）
+	private User user;
 
 	private String title;
 
@@ -29,18 +32,18 @@ public class Blog {
 	}
 
 	// 新規作成用のコンストラクタ
-	public Blog(Integer categoryId, Integer userId, String title, String body) {
-		this.categoryId = categoryId;
-		this.userId = userId;
+	public Blog(Category category, User user, String title, String body) {
+		this.category = category;
+		this.user = user;
 		this.title = title;
 		this.body = body;
 	}
 
 	// 更新用コンストラクタ
-	public Blog(Integer id, Integer categoryId, Integer userId, String title, String body) {
+	public Blog(Integer id, Category category, User user, String title, String body) {
 		this.id = id;
-		this.categoryId = categoryId;
-		this.userId = userId;
+		this.category = category;
+		this.user = user;
 		this.title = title;
 		this.body = body;
 	}
@@ -51,14 +54,14 @@ public class Blog {
 		return id;
 	}
 
-	public Integer getCategoryId() {
+	public Category getCategory() {
 
-		return categoryId;
+		return category;
 	}
 
-	public Integer getUserId() {
+	public User getUser() {
 
-		return userId;
+		return user;
 	}
 
 	public String getTitle() {

--- a/src/main/java/com/example/demo/entity/User.java
+++ b/src/main/java/com/example/demo/entity/User.java
@@ -1,9 +1,12 @@
 package com.example.demo.entity;
 
+import java.util.List;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 @Entity
@@ -16,6 +19,11 @@ public class User {
 	private String name;
 	private String email;
 	private String password;
+
+	// JPAリレーション
+	// ユーザーのBlog一覧取得用
+	@OneToMany(mappedBy = "user")
+	private List<Blog> blogs;
 
 	// コンストラクタ
 	public User() {

--- a/src/main/java/com/example/demo/model/Account.java
+++ b/src/main/java/com/example/demo/model/Account.java
@@ -20,7 +20,7 @@ public class Account {
 		this.name = name;
 	}
 
-	// ゲッター＆セッター
+	// ゲッター
 	public String getName() {
 
 		return name;
@@ -31,8 +31,24 @@ public class Account {
 		return id;
 	}
 
+	// セッター
 	public void setName(String name) {
 		this.name = name;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	// ログイン状態を確認するメソッド（未使用）
+	public boolean isLoggedIn() {
+		return id != null && name != null && !name.isEmpty();
+	}
+
+	// デバッグ・ログ出力用
+	@Override
+	public String toString() {
+		return "Account{id = " + id + ", name = '" + name + "'}";
 	}
 
 }

--- a/src/main/java/com/example/demo/repository/BlogRepository.java
+++ b/src/main/java/com/example/demo/repository/BlogRepository.java
@@ -1,9 +1,16 @@
 package com.example.demo.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.demo.entity.Blog;
 
 public interface BlogRepository extends JpaRepository<Blog, Integer> {
+
+	// BlogエンティティでcategoryIdが一致する全てを取得する
+	// 複数の結果が返ってくるので戻り値はList<Blog>
+	// SELECT * FROM blog WHERE category_id = ?;
+	List<Blog> findByCategoryId(Integer categoryId);
 
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -14,8 +14,17 @@ INSERT INTO categories (id, name) VALUES
 INSERT INTO users (email, name, password) VALUES
 ('tanaka@aaa.com', '田中太郎', 'test123'),
 ('suzuki@aaa.com', '鈴木一郎', 'test456'),
-('testuser@com', 'テストユーザー', 'testuser');
+('testuser@com', 'テストユーザー', 'testuser'),
+('test@com', 'テスト', 'testuser');
 
 -- blogs テーブルにデータを挿入
-INSERT INTO blogs (id, category_id, user_id, title, body) VALUES
-(1, 1, 1, '見積もり', '見積もり金額を明日までに提出');
+--INSERT INTO blogs (id, category_id, user_id, title, body) VALUES
+--(1, 1, 1, '見積もり', '見積もり金額を明日までに提出');
+
+INSERT INTO blogs (category_id, user_id, title, body) VALUES
+(1, 1, '見積もり', '見積もり金額を明日までに提出'),
+(2, 1, 'ゲームの作り方', 'ゲームの作り方を明日までに考える'),
+(3, 1, 'コーヒー豆の煎り方', 'コーヒー豆の煎り方を明日までにマスターする'),
+(1, 2, '請求', '請求金額を明日までに提出'),
+(2, 2, '漫画の描き方', '漫画の描き方を明日までにマスターする'),
+(3, 3, 'リマインド', '明日までにリマインドをする');

--- a/src/main/resources/templates/blogs.html
+++ b/src/main/resources/templates/blogs.html
@@ -1,10 +1,54 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
+
 <head>
-<meta charset="UTF-8">
-<title>ブログ一覧</title>
+	<meta charset="UTF-8">
+	<title>ブログ一覧画面</title>
 </head>
+
 <body>
-ここはブログ一覧画面です
+
+	<nav class="">
+		<div class="">
+			<a href="/blogs">全商品</a>
+			<a th:each="category:${categories}" th:href="@{/blogs(categoryId=${category.id})}">
+				<span th:text="${category.name}"></span>
+			</a>
+		</div>
+	</nav>
+
+	<div class="">
+		<table class="">
+			<tr class="">
+				<th class="">NO</th>
+				<th class="">タイトル</th>
+				<th class="">カテゴリー</th>
+				<th class="">変更</th>
+				<th class="">削除</th>
+			</tr>
+			<tr th:each="blog:${blogs}" class="">
+				<td th:text="${blog.id}" class=""></td>
+				<td th:text="${blog.title}" class=""></td>
+
+				<!--# Thymeleafはドットでつないだプロパティ呼び出しは、順にget〇〇() をたどっていく仕組み
+				 なので、blog.getCategory().getName()と同じになる #-->
+				<td th:text="${blog.category.name}" class=""></td>
+				<td class="">
+					<form action="/blogs/edit" method="get">
+						<input type="hidden" name="blogId" th:value="${blog.id}">
+						<button class="">変更</button>
+					</form>
+				</td>
+				<td class="">
+					<form action="/blogs/delete" method="post">
+						<input type="hidden" name="blogId" th:value="${blog.id}">
+						<button class="">削除</button>
+					</form>
+				</td>
+			</tr>
+		</table>
+	</div>
+
 </body>
+
 </html>


### PR DESCRIPTION
@yuuuki-miyaaa 
- [x] エンティティの外部キー定義をリレーションに修正
→外部キーのcategory_idからカテゴリー名を取得できるようにと、今後の改修でログインユーザーの記事一覧が取得できるようにリレーションを定義
- [x] ブログ全記事の表示画面の実装
- [x] ブログ記事のカテゴリーでの絞り込みの実装
- [x] ログイン情報をHttpSessionではなくAccountで管理に変更
→AOPの実装でページが遷移しない不具合が起きたため修正
- [x] 初期データの追加
→テストを用意にするため追加